### PR TITLE
fix: Clipply warnings

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -63,7 +63,7 @@ fn check_version(
             let mut operator = expect_punct(it);
             let mut rhs_token = it.next().unwrap();
             if let TokenTree::Punct(punct) = &rhs_token {
-                operator = operator + &punct.to_string();
+                operator.extend(std::iter::once(punct.as_char()));
                 rhs_token = it.next().unwrap();
             }
             let rhs_name = if let TokenTree::Ident(ident) = &rhs_token {


### PR DESCRIPTION
Mostly fixes around unecessary allocations and uses of match statements where if let would suffice

All remaining warnins are regarding the python generated structs which have fields that don't follow snake case naming, ideally rename those fields, or add the #[allow(non_snake_case)] attribute to Python generated structs.